### PR TITLE
Set up warnastrophy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
             # 7. Load google-services.json from the secrets
             - name: Decode secrets
               env:
-                GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+                FIREBASESECRET: ${{ secrets.FIREBASESECRET }}
               run:
-                echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services,json
+                echo "$FIREBASESECRET" | base64 --decode > ./app/google-services,json
             
             - name: AVD cache
               uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+name: Android CI
+
+on:
+    push:
+        branches:
+            - main
+            - 'feature/**'
+            - 'refactor/**'
+            - 'fix/**'
+            - 'ci/**'
+            
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+
+jobs:
+    ci:
+        name: CI-warnastrophy
+        runs-on: ubuntu-latest
+
+        env:
+            app-name: warnastrophy
+        
+        steps:
+            # 1. Checkout repository on runner
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                submodules: recursive
+                fetch-depth: 0
+            
+            # 2. Remove current gradle cache to avoid caching issues
+            - name: Remove current gradle cache
+              run: rm -rf ~/.gradle
+
+            # 3. Enable Kernel-based Virtual Machine (KVM) to allow Android emulator to run faster
+            - name: Enable KVM group perms
+              run: |
+                echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+                sudo udevadm control --reload-rules
+                sudo udevadm trigger --name-match=kvm
+            
+            # 4. Setup JDK for Kotlin/Java projects
+            - name: Setup JDK
+              uses: actions/setup-java@v4
+              with:
+                distribution: "temurin"
+                java-version: "17"
+            
+            # 5. Cache gradle folder to reuse it later
+            # path : path to files to cache
+            # key : explicit key for cache entry
+            # restore-keys : used for restoring stale cache if no cache hit occurred for key
+            - name: Retrieve gradle cache
+              uses: actions/cache@v4
+              with:
+                path: |
+                    ~/.gradle/cache
+                    ~/.gradle/wrapper
+                key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties') }}
+                restore-keys: ${{ runner.os }}-gradle
+            
+            # 6. Cache gradle files to speed up build process
+            - name: Gradle cache
+              uses: gradle/actions/setup-gradle@v3
+
+            # 7. Load google-services.json from the secrets
+            - name: Decode secrets
+              env:
+                GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+              run:
+                echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services,json
+            
+            - name: AVD cache
+              uses: actions/cache@v4
+              id: avd-cache
+              with:
+                path: |
+                    ~/.android/avd/*
+                    ~/.android/adb*
+                key: avd-34
+            
+            - name: create AVD and generate snapshot for caching
+              if: steps.avd-cache.outputs.cache-hit != 'true'
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                api-level: 34
+                target: google_apis
+                arch: x86_64
+                force-avd-creation: false
+                emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back virtualscene
+                disable-animations: false
+                script: echo "Generated AVD snapshot for caching."
+            
+            - name: Grant execute permissions for gradlew
+              run: chmod +x ./gradlew
+            
+            # 8. Check formatting
+            - name: Ktfmt Check
+              run: ./gradlew ktfmtCheck
+
+            # 9. Build application
+            - name: Assemble
+              run: ./gradlew assembleDebug lint --parallel --build_cache
+
+            # 10. Run Unit tests
+            - name: Run tests
+              run: ./gradlew check --parallel --build_cache
+
+            # 11. Run connected tests on emulator
+            - name: Run instrumentation tests
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                api-level: 34
+                target: google_apis
+                arch: x86_64
+                avd-name: github
+                force-avd-creation: false
+                emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back virtualscene
+                disable-animations: false
+                script: ./gradlew connectedCheck --parallel --build_cache
+
+            # 12. Generate coverage report for testing purposes
+            - name: Generate coverage report
+              run: ./gradlew jacocoTestReport
+
+            # 13. Upload coverage report (optional if needed in another job)
+            - name: Upload coverage
+              uses: actions/upload-artifact@v4
+              with:
+                name: Coverage report
+                path: app/build/reports/jacoco/jacocoTestReport

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
               env:
                 FIREBASESECRET: ${{ secrets.FIREBASESECRET }}
               run:
-                echo "$FIREBASESECRET" | base64 --decode > ./app/google-services,json
+                echo "$FIREBASESECRET" | base64 --decode > ./app/google-services.json
             
             - name: AVD cache
               uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,11 @@ jobs:
 
             # 9. Build application
             - name: Assemble
-              run: ./gradlew assembleDebug lint --parallel --build_cache
+              run: ./gradlew assembleDebug lint --parallel --build-cache
 
             # 10. Run Unit tests
             - name: Run tests
-              run: ./gradlew check --parallel --build_cache
+              run: ./gradlew check --parallel --build-cache
 
             # 11. Run connected tests on emulator
             - name: Run instrumentation tests
@@ -120,7 +120,7 @@ jobs:
                 force-avd-creation: false
                 emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back virtualscene
                 disable-animations: false
-                script: ./gradlew connectedCheck --parallel --build_cache
+                script: ./gradlew connectedCheck --parallel --build-cache
 
             # 12. Generate coverage report for testing purposes
             - name: Generate coverage report

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.2"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     compileOptions {
@@ -159,7 +159,7 @@ dependencies {
     // TODO: Add the dependencies for Firebase products you want to use
     // See https://firebase.google.com/docs/android/setup#available-libraries
     // For example, add the dependencies for Firebase Authentication and Cloud Firestore
-    implementation("com.google.firebase:firebase-auth:23.1.0")
+    implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -159,7 +159,7 @@ dependencies {
     // TODO: Add the dependencies for Firebase products you want to use
     // See https://firebase.google.com/docs/android/setup#available-libraries
     // For example, add the dependencies for Firebase Authentication and Cloud Firestore
-    implementation("com.google.firebase:firebase-auth")
+    implementation("com.google.firebase:firebase-auth:23.1.0")
     implementation("com.google.firebase:firebase-firestore")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,7 +152,7 @@ dependencies {
 
     // --------------- firebase -------------------
     // Import the Firebase BoM
-    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
+    implementation(platform("com.google.firebase:firebase-bom:32.8.1"))
 
     // When using the BoM, you don't specify versions in Firebase library dependencies
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.3.0"
-kotlin = "1.8.10"
+kotlin = "2.1.0"
 coreKtx = "1.12.0"
 ktfmt = "0.17.0"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.3.0"
-kotlin = "2.1.0"
+kotlin = "1.9.24"
 coreKtx = "1.12.0"
 ktfmt = "0.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
This PR adds **a continuous integration (CI) pipeline** for the warnastrophy application using **GitHub Actions**.

**Changes:**
- Added an `Android CI`workflow in `./github/workflows/`
- Build and unit tests with Gradle
- Code formatting check with **ktfmt**
- Assemble a debug APK
- Run **instrumented tests** on an Android emulator (with KVM enabled for better performance)
- Generate coverage reports with Jacoco and upload an artifact
- Secure handling of `google-services.json` via **GitHub Secrets**

**Expected outcome:**
- Every push or pull request on `main` triggers the CI
- Builds will fail if:
   - Formatting is incorrect
   - Unit tests fail
   - Instrumented tests fail