### PR TITLE
Feature: Integrate SonarCloud Analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,10 @@ jobs:
               with:
                 name: Coverage report
                 path: app/build/reports/jacoco/jacocoTestReport
+
+            # 14. Update coverage reports to SonarCloud
+            - name: Upload coverage report to SonarCloud
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+              run: ./gradlew sonar --parallel --build-cache

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,10 +94,11 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "gf_android-sample")
-        property("sonar.projectName", "Android-Sample")
-        property("sonar.organization", "gabrielfleischer")
+        property("sonar.projectKey", "SWENTapp_warnastrophy")
+        property("sonar.projectName", "warnastrophy")
+        property("sonar.organization", "SWENTapp")
         property("sonar.host.url", "https://sonarcloud.io")
+        property("sonar.login", System.getenv("SONAR_TOKEN"))
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
         // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,7 +96,7 @@ sonar {
     properties {
         property("sonar.projectKey", "SWENTapp_warnastrophy")
         property("sonar.projectName", "warnastrophy")
-        property("sonar.organization", "SWENTapp")
+        property("sonar.organization", "swentapp")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.login", System.getenv("SONAR_TOKEN"))
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+sonar.gradle.skipCompile=true


### PR DESCRIPTION
This PR integrates SonarCloud analysis into the CI pipeline for the `warnastrophy` application.

**Changes:**
- Added SonarCloud plugin and configuration in `build.gradle.kts`
- Set `sonar.gradle.skipCompile=true` to avoid deprecation warnings
- SonarCloud token injected securely via CI environment variable (`SONAR_TOKEN`)
- Upload coverage reports generated by Jacoco to SonarCloud for analysis

**Expected outcome:**
- Every push or pull request triggers SonarCloud analysis
- Build will fail if:
   - SonarCloud analysis cannot run
   - Coverage or lint reports are missing or invalid