### PR TITLE
fix: read local.properties content from secrets to env for decoding

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -22,12 +22,17 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # 3. Decode the keystore and local properties from GitHub Secrets
+      # 3. Decode from GitHub Secrets
       - name: Decode Keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: |
           echo $KEYSTORE_BASE64 | base64 --decode > ./app/release.jks
+
+      - name: Decode Local Properties
+        env:
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run:
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
 
       - name: Decode Firebase Config


### PR DESCRIPTION
The last fix didn't actually read the local.properties secret, that was an oversight on my part. This time I made sure it worked and ran it, take a look [here](https://github.com/SWENTapp/warnastrophy/actions/runs/18501689027) and confirm.