### PR TITLE
Implement HealthCardViewModel (without tests)

### DIFF
--- a/app/src/main/java/com/github/warnastrophy/core/ui/healthcard/HealthCardViewModel.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/healthcard/HealthCardViewModel.kt
@@ -14,135 +14,132 @@ import kotlinx.coroutines.launch
 /**
  * ViewModel responsible for managing the health card feature.
  *
- * Handles loading, saving, updating, and deleting a HealthCard.
- * Exposes the current card and UI state as [StateFlow] for Compose or other observers.
+ * Handles loading, saving, updating, and deleting a HealthCard. Exposes the current card and UI
+ * state as [StateFlow] for Compose or other observers.
  */
 class HealthCardViewModel : ViewModel() {
 
-    private val _uiState = MutableStateFlow<HealthCardUiState>(HealthCardUiState.Idle)
-    val uiState: StateFlow<HealthCardUiState> = _uiState.asStateFlow()
+  private val _uiState = MutableStateFlow<HealthCardUiState>(HealthCardUiState.Idle)
+  val uiState: StateFlow<HealthCardUiState> = _uiState.asStateFlow()
 
-    private val _currentCard = MutableStateFlow<HealthCard?>(null)
-    val currentCard: StateFlow<HealthCard?> = _currentCard.asStateFlow()
+  private val _currentCard = MutableStateFlow<HealthCard?>(null)
+  val currentCard: StateFlow<HealthCard?> = _currentCard.asStateFlow()
 
-    /**
-     * Loads the health card for a given user from storage.
-     *
-     * Updates [_currentCard] and [_uiState] accordingly.
-     *
-     * @param context Context used for storage access
-     * @param userId The unique identifier of the user
-     */
-    fun loadHealthCard(context: Context, userId: String) {
-        viewModelScope.launch {
-            _uiState.value = HealthCardUiState.Loading
-            when(val result = HealthCardStorage.loadHealthCard(context, userId)){
-                is StorageResult.Success -> {
-                    _currentCard.value = result.data
-                    _uiState.value = HealthCardUiState.Success("Health card successfully loaded")
-                }
-                is StorageResult.Error -> {
-                    _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Loading error")
-                }
-            }
+  /**
+   * Loads the health card for a given user from storage.
+   *
+   * Updates [_currentCard] and [_uiState] accordingly.
+   *
+   * @param context Context used for storage access
+   * @param userId The unique identifier of the user
+   */
+  fun loadHealthCard(context: Context, userId: String) {
+    viewModelScope.launch {
+      _uiState.value = HealthCardUiState.Loading
+      when (val result = HealthCardStorage.loadHealthCard(context, userId)) {
+        is StorageResult.Success -> {
+          _currentCard.value = result.data
+          _uiState.value = HealthCardUiState.Success("Health card successfully loaded")
         }
-    }
-
-    /**
-     * Saves a new health card for a user.
-     *
-     * Updates [_currentCard] and [_uiState] on success or failure.
-     *
-     * @param context Context used for storage access
-     * @param userId The unique identifier of the user
-     * @param card The HealthCard to save
-     */
-    fun saveHealthCard(context: Context, userId: String, card: HealthCard) {
-        viewModelScope.launch {
-            _uiState.value = HealthCardUiState.Loading
-            when(val result = HealthCardStorage.saveHealthCard(context, userId, card)) {
-                is StorageResult.Success -> {
-                    _currentCard.value = card
-                    _uiState.value = HealthCardUiState.Success("Health card saved successfully")
-                }
-                is StorageResult.Error -> {
-                    _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Saving error")
-                }
-            }
+        is StorageResult.Error -> {
+          _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Loading error")
         }
+      }
     }
+  }
 
-    /**
-     * Updates an existing health card.
-     *
-     * The current card is updated immediately on success to reflect changes in the UI.
-     *
-     * @param context Context used for storage access
-     * @param userId The unique identifier of the user
-     * @param newCard The updated HealthCard data
-     */
-    fun updateHealthCard(context: Context, userId: String, newCard: HealthCard) {
-        viewModelScope.launch {
-            _uiState.value = HealthCardUiState.Loading
-            when(val result = HealthCardStorage.updateHealthCard(context, userId, newCard)) {
-                is StorageResult.Success -> {
-                    _currentCard.value = newCard
-                    _uiState.value = HealthCardUiState.Success("Health card updated successfully")
-                }
-                is StorageResult.Error -> {
-                    _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Updating error")
-                }
-            }
+  /**
+   * Saves a new health card for a user.
+   *
+   * Updates [_currentCard] and [_uiState] on success or failure.
+   *
+   * @param context Context used for storage access
+   * @param userId The unique identifier of the user
+   * @param card The HealthCard to save
+   */
+  fun saveHealthCard(context: Context, userId: String, card: HealthCard) {
+    viewModelScope.launch {
+      _uiState.value = HealthCardUiState.Loading
+      when (val result = HealthCardStorage.saveHealthCard(context, userId, card)) {
+        is StorageResult.Success -> {
+          _currentCard.value = card
+          _uiState.value = HealthCardUiState.Success("Health card saved successfully")
         }
-    }
-
-    /**
-     * Deletes the health card of a user.
-     *
-     * Clears [_currentCard] and updates [_uiState] accordingly.
-     *
-     * @param context Context used for storage access
-     * @param userId The unique identifier of the user
-     */
-    fun deleteHealthCard(context: Context, userId: String){
-        viewModelScope.launch {
-            _uiState.value = HealthCardUiState.Loading
-            when(val result = HealthCardStorage.deleteHealthCard(context, userId)) {
-                is StorageResult.Success -> {
-                    _currentCard.value = null
-                    _uiState.value = HealthCardUiState.Success("Health card deleted successfully")
-                }
-                is StorageResult.Error -> {
-                    _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Deletion error")
-                }
-            }
+        is StorageResult.Error -> {
+          _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Saving error")
         }
+      }
     }
+  }
 
-    /**
-     * Resets the UI state to [Idle].
-     *
-     * Useful after showing a success or error message.
-     */
-    fun resetUiState() {
-        _uiState.value = HealthCardUiState.Idle
+  /**
+   * Updates an existing health card.
+   *
+   * The current card is updated immediately on success to reflect changes in the UI.
+   *
+   * @param context Context used for storage access
+   * @param userId The unique identifier of the user
+   * @param newCard The updated HealthCard data
+   */
+  fun updateHealthCard(context: Context, userId: String, newCard: HealthCard) {
+    viewModelScope.launch {
+      _uiState.value = HealthCardUiState.Loading
+      when (val result = HealthCardStorage.updateHealthCard(context, userId, newCard)) {
+        is StorageResult.Success -> {
+          _currentCard.value = newCard
+          _uiState.value = HealthCardUiState.Success("Health card updated successfully")
+        }
+        is StorageResult.Error -> {
+          _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Updating error")
+        }
+      }
     }
+  }
+
+  /**
+   * Deletes the health card of a user.
+   *
+   * Clears [_currentCard] and updates [_uiState] accordingly.
+   *
+   * @param context Context used for storage access
+   * @param userId The unique identifier of the user
+   */
+  fun deleteHealthCard(context: Context, userId: String) {
+    viewModelScope.launch {
+      _uiState.value = HealthCardUiState.Loading
+      when (val result = HealthCardStorage.deleteHealthCard(context, userId)) {
+        is StorageResult.Success -> {
+          _currentCard.value = null
+          _uiState.value = HealthCardUiState.Success("Health card deleted successfully")
+        }
+        is StorageResult.Error -> {
+          _uiState.value = HealthCardUiState.Error(result.exception.message ?: "Deletion error")
+        }
+      }
+    }
+  }
+
+  /**
+   * Resets the UI state to [Idle].
+   *
+   * Useful after showing a success or error message.
+   */
+  fun resetUiState() {
+    _uiState.value = HealthCardUiState.Idle
+  }
 }
 
-
-/**
- * Represents the UI state of the HealthCard screen.
- */
+/** Represents the UI state of the HealthCard screen. */
 sealed class HealthCardUiState {
-    /** Initial state, no action performed yet */
+  /** Initial state, no action performed yet */
   data object Idle : HealthCardUiState()
 
-    /** Loading state, operation in progress */
+  /** Loading state, operation in progress */
   data object Loading : HealthCardUiState()
 
-    /** Successful operation with an optional message */
+  /** Successful operation with an optional message */
   data class Success(val message: String) : HealthCardUiState()
 
-    /** Failed operation with an error message */
+  /** Failed operation with an error message */
   data class Error(val message: String) : HealthCardUiState()
 }


### PR DESCRIPTION
This PR introduces the HealthCardViewModel, responsible for managing the core logic of the HealthCard feature.

Key functionalities include:
- Loading an existing health card for a user.
- Saving a new health card.
- Updating an existing health card.
- Deleting a health card.
- Exposing the current HealthCard and UI state via StateFlow for Compose or other observers.
- Resetting the UI state after operations.

Note: Unit tests for the ViewModel will be added in a separate PR to keep this implementation focused and reviewable.