### PR TITLE
fix: create factory for services

### DIFF
--- a/app/src/main/java/com/github/warnastrophy/WarnastrophyApp.kt
+++ b/app/src/main/java/com/github/warnastrophy/WarnastrophyApp.kt
@@ -5,22 +5,25 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.github.warnastrophy.core.data.repository.HazardRepositoryProvider
 import com.github.warnastrophy.core.model.ErrorHandler
-import com.github.warnastrophy.core.model.GpsService
-import com.github.warnastrophy.core.model.HazardsService
+import com.github.warnastrophy.core.model.GpsServiceFactory
+import com.github.warnastrophy.core.model.HazardsServiceFactory
 import com.github.warnastrophy.core.model.PermissionManager
 import com.github.warnastrophy.core.ui.dashboard.DashboardScreen
 import com.github.warnastrophy.core.ui.healthcard.HealthCardScreen
 import com.github.warnastrophy.core.ui.map.MapScreen
 import com.github.warnastrophy.core.ui.map.MapViewModel
+import com.github.warnastrophy.core.ui.map.MapViewModelFactory
 import com.github.warnastrophy.core.ui.navigation.BottomNavigationBar
 import com.github.warnastrophy.core.ui.navigation.NavigationActions
 import com.github.warnastrophy.core.ui.navigation.Screen
@@ -66,12 +69,20 @@ fun WarnastrophyApp(mockMapScreen: (@Composable () -> Unit)? = null) {
 
   val errorHandler = ErrorHandler()
 
-  val gpsService = GpsService(locationClient, errorHandler)
+  val gpsServiceFactory = remember { GpsServiceFactory(locationClient, errorHandler) }
+  val gpsService = remember { gpsServiceFactory.create() }
 
   val hazardsRepository = HazardRepositoryProvider.repository
-  val hazardsService = HazardsService(hazardsRepository, gpsService, errorHandler)
+
+  val hazardsServiceFactory = remember {
+    HazardsServiceFactory(hazardsRepository, gpsService, errorHandler)
+  }
+  val hazardsService = remember { hazardsServiceFactory.create() }
 
   val permissionManager = PermissionManager(context)
+  val mapViewModelFactory = remember {
+    MapViewModelFactory(gpsService, hazardsService, permissionManager)
+  }
 
   Scaffold(
       bottomBar = { BottomNavigationBar(currentScreen, navController) },
@@ -87,10 +98,10 @@ fun WarnastrophyApp(mockMapScreen: (@Composable () -> Unit)? = null) {
             startDestination = startDestination,
             modifier = Modifier.padding(innerPadding)) {
               composable(Dashboard.route) { DashboardScreen() }
-              composable(Map.route) {
-                mockMapScreen?.invoke()
-                    ?: MapScreen(
-                        viewModel = MapViewModel(gpsService, hazardsService, permissionManager))
+              composable(Map.route) { backStackEntryForMap ->
+                val mapViewModel: MapViewModel =
+                    viewModel(backStackEntryForMap, factory = mapViewModelFactory)
+                mockMapScreen?.invoke() ?: MapScreen(viewModel = mapViewModel)
               }
               composable(Profile.route) {
                 ProfileScreen(

--- a/app/src/main/java/com/github/warnastrophy/core/model/GpsService.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/model/GpsService.kt
@@ -247,3 +247,12 @@ sealed class GpsResult {
    */
   data class Success(val message: String = "Success") : GpsResult()
 }
+
+class GpsServiceFactory(
+    private val locationClient: FusedLocationProviderClient,
+    private val errorHandler: ErrorHandler
+) {
+  fun create(): GpsService {
+    return GpsService(locationClient, errorHandler)
+  }
+}

--- a/app/src/main/java/com/github/warnastrophy/core/model/HazardsService.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/model/HazardsService.kt
@@ -105,3 +105,13 @@ data class FetcherState(
     val isLoading: Boolean = false,
     val errorMsg: String? = null
 )
+
+class HazardsServiceFactory(
+    private val repository: HazardsDataSource,
+    private val gpsService: PositionService,
+    private val errorHandler: ErrorHandler
+) {
+  fun create(): HazardsService {
+    return HazardsService(repository, gpsService, errorHandler)
+  }
+}

--- a/app/src/main/java/com/github/warnastrophy/core/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/map/MapViewModel.kt
@@ -2,12 +2,16 @@ package com.github.warnastrophy.core.ui.map
 
 import android.app.Activity
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.warnastrophy.core.model.AppPermissions
 import com.github.warnastrophy.core.model.FetcherState
 import com.github.warnastrophy.core.model.GpsPositionState
+import com.github.warnastrophy.core.model.GpsService
 import com.github.warnastrophy.core.model.Hazard
 import com.github.warnastrophy.core.model.HazardsDataService
+import com.github.warnastrophy.core.model.HazardsService
+import com.github.warnastrophy.core.model.PermissionManager
 import com.github.warnastrophy.core.model.PermissionManagerInterface
 import com.github.warnastrophy.core.model.PermissionResult
 import com.github.warnastrophy.core.model.PositionService
@@ -163,5 +167,33 @@ class MapViewModel(
           (group.key ?: "Unknown") to Pair(minSev, maxSev)
         }
         .toMap()
+  }
+}
+
+/**
+ * Defines a composable for the map route (Map.route).
+ *
+ * @param backStackEntryForMap The navigation back stack entry associated with the current route.
+ *   Used to bind the ViewModel's lifecycle to this destination.
+ *
+ * Features:
+ * - Creates an instance of `MapViewModel` using `viewModel` and a `MapViewModelFactory`.
+ * - Associates the `MapViewModel` with the lifecycle of the `Map.route` destination.
+ * - If `mockMapScreen` is provided (non-null), it is invoked for testing or overrides. Otherwise,
+ *   the `MapScreen` composable is displayed with the `mapViewModel` as a parameter.
+ *
+ * @see viewModel
+ * @see MapViewModelFactory
+ */
+class MapViewModelFactory(
+    private val gpsService: GpsService,
+    private val hazardsService: HazardsService,
+    private val permissionManager: PermissionManager
+) : ViewModelProvider.Factory {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    if (modelClass.isAssignableFrom(MapViewModel::class.java)) {
+      return MapViewModel(gpsService, hazardsService, permissionManager) as T
+    }
+    throw IllegalArgumentException("Unknown ViewModel class: $modelClass")
   }
 }


### PR DESCRIPTION
#107

Summary
- Introduces factories to improve code structure and retain data across configuration changes (e.g., screen rotations).
- Fixes a bug where navigating recreated a MapViewModel each time, causing multiple instances to run concurrently.

Motivation
- Ensure consistent state retention during rotations.
- Prevent duplicate ViewModel instances and redundant GPS updates, improving performance and user experience.

Changes
- Add ViewModel factories to centralize and standardize ViewModel creation.
- Use a single ViewModel per destination to preserve instances across configuration changes.

Bug Fix
- Resolve an issue where each navigation recreated a MapViewModel, leading to multiple concurrent instances and conflicting updates. The factory and proper scoping ensure only one instance is active per destination.


This PR was generated by chatGPT