### PR TITLE
Fix navigation bar bug

### DIFF
--- a/app/src/main/java/com/github/warnastrophy/core/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/navigation/BottomNavigationBar.kt
@@ -47,7 +47,7 @@ fun BottomNavigationBar(currentScreen: Screen, navController: NavController) {
               // Avoid multiple copies of the same destination when spamming the same item
               launchSingleTop = true
               // Allow staying on the same screen after activity recreation (rotation, kill ?)
-              restoreState = true
+              restoreState = false
             }
           })
     }


### PR DESCRIPTION
## Why this PR necssary:
On initial Dashboard screen, when we navigate to Health Card screen, then Profile Screen and then Dashboard screen. The Dashboard screen still shows Health Card screen but we want Dashboard screen to show its initial screen instead of restoring its state.

## What this PR does:
Change a boolean so the state is not restored when we visit the same tab on navigation bar