### PR TITLE
Implement skeleton for DangerModeService

### DIFF
--- a/app/src/main/java/com/github/warnastrophy/core/data/service/DangerModeService.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/data/service/DangerModeService.kt
@@ -69,10 +69,10 @@ class DangerModeService {
   /**
    * Sets the danger level for Danger Mode.
    *
-   * @param level The danger level to set.
+   * @param level The danger level to set, coerced to be in [0, 3]
    */
   fun setDangerLevel(level: Int) {
-    _state.value = _state.value.copy(dangerLevel = level)
+    _state.value = _state.value.copy(dangerLevel = level.coerceIn(0, 3))
   }
 
   /** Manually activates Danger Mode. */

--- a/app/src/test/java/com/github/warnastrophy/core/data/service/DangerModeServiceTest.kt
+++ b/app/src/test/java/com/github/warnastrophy/core/data/service/DangerModeServiceTest.kt
@@ -1,0 +1,45 @@
+package com.github.warnastrophy.core.data.service
+
+import com.github.warnastrophy.core.ui.features.dashboard.DangerModePreset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DangerModeServiceTest {
+  private lateinit var service: DangerModeService
+
+  @Before
+  fun setUp() {
+    // Assuming DangerModeService can be instantiated directly
+    service = DangerModeService()
+  }
+
+  @Test
+  fun `isDangerModeActive is false by default`() {
+    assertFalse(service.state.value.isActive)
+  }
+
+  @Test
+  fun `deactivateDangerMode sets danger mode to false`() {
+    // First activate
+    service.manualActivate()
+    assertTrue(service.state.value.isActive)
+
+    // Then deactivate
+    service.manualDeactivate()
+    assertFalse(service.state.value.isActive)
+  }
+
+  @Test
+  fun basicSetsWork() {
+    service.setDangerLevel(3)
+    assertTrue(service.state.value.dangerLevel == 3)
+    service.setPreset(DangerModePreset.CLIMBING_MODE)
+    assertTrue(service.state.value.preset == DangerModePreset.CLIMBING_MODE)
+    val set = setOf("GPS_MONITORING", "ALERT_SENDING")
+    service.setCapabilities(set)
+    assertEquals(set, service.state.value.capabilities)
+  }
+}


### PR DESCRIPTION
This pull request introduces a new service class, `DangerModeService`, which is responsible for managing the Danger Mode feature in the application. The service provides a central place to track the state of Danger Mode, including activation status, presets, capabilities, and danger levels, along with methods to update these properties and manually activate or deactivate the mode.

New Danger Mode management service:

* Added the `DangerModeService` class to encapsulate all logic related to Danger Mode activation, deactivation, and state management. (`DangerModeService.kt`)
* Defined the `DangerModeState` data class to represent the current state of Danger Mode, including fields for activation status, time, hazard, preset, capabilities, and danger level. (`DangerModeService.kt`)

State management and update methods:
* Added methods to set the preset, capabilities, and danger level for Danger Mode. (`DangerModeService.kt`)

The tests are very basic, as is the added code, only for the sake of code coverage

Generated by Copilot and edited