### PR TITLE
Inject missing GitHub secrets to release pipeline required for GitHub authentication

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -32,8 +32,12 @@ jobs:
       - name: Decode Local Properties
         env:
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
         run:
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo "github.client.id=$CLIENT_ID" >> ./local.properties
+          echo "github.client.secret=$CLIENT_SECRET" >> ./local.properties
 
       - name: Decode Firebase Config
         env:


### PR DESCRIPTION
This PR introduces a fix to the release pipeline where the `github.client.id` and `github.client.secret` attributes were missing in the reconstructed `local.properties` resulting in a bug where the GitHub authentication did not work properly in the release APK.

This PR addresses the issue by injecting the missing GitHub secrets into the release pipeline.