### PR TITLE
Feature/danger mode options

### DIFF
--- a/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardTest.kt
+++ b/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardTest.kt
@@ -201,4 +201,93 @@ class DangerModeCardTest : BaseAndroidComposeTest() {
 
     assert(viewModel.dangerLevel.value.ordinal > DangerLevel.LOW.ordinal)
   }
+
+  @Test
+  fun dangerModeCard_advancedSection_shownWhenCapabilitySelected() {
+    lateinit var viewModel: DangerModeCardViewModel
+    composeTestRule.setContent {
+      viewModel = testViewModel
+      MaterialTheme { DangerModeCard(viewModel = viewModel) }
+    }
+
+    // Advanced section should not be visible initially
+    composeTestRule
+        .onNodeWithTag(DangerModeTestTags.ADVANCED_SECTION, useUnmergedTree = true)
+        .assertDoesNotExist()
+
+    // Enable CALL capability
+    val callCapabilityNode =
+        composeTestRule.onNodeWithTag(
+            DangerModeTestTags.capabilityTag(DangerModeCapability.CALL), useUnmergedTree = true)
+    callCapabilityNode.performClick()
+
+    // Advanced section should now be visible
+    composeTestRule
+        .onNodeWithTag(DangerModeTestTags.ADVANCED_SECTION, useUnmergedTree = true)
+        .assertIsDisplayed()
+
+    // Auto actions switch should exist and be off by default
+    composeTestRule
+        .onNodeWithTag(DangerModeTestTags.AUTO_CALL_SWITCH, useUnmergedTree = true)
+        .assertIsOff()
+
+    // Confirmation switches should exist and be off by default
+    composeTestRule
+        .onNodeWithTag(DangerModeTestTags.CONFIRM_TOUCH_SWITCH, useUnmergedTree = true)
+        .assertIsOff()
+    composeTestRule
+        .onNodeWithTag(DangerModeTestTags.CONFIRM_VOICE_SWITCH, useUnmergedTree = true)
+        .assertIsOff()
+  }
+
+  /* Advanced switches update their respective state in the ViewModel independently */
+  @Test
+  fun dangerModeCard_advancedSwitches_updateViewModelState_independently() {
+    lateinit var viewModel: DangerModeCardViewModel
+    composeTestRule.setContent {
+      viewModel = testViewModel
+      MaterialTheme { DangerModeCard(viewModel = viewModel) }
+    }
+
+    // Enable CALL capability to show advanced section
+    val callCapabilityNode =
+        composeTestRule.onNodeWithTag(
+            DangerModeTestTags.capabilityTag(DangerModeCapability.CALL), useUnmergedTree = true)
+    callCapabilityNode.performClick()
+
+    val autoActionsSwitch =
+        composeTestRule.onNodeWithTag(DangerModeTestTags.AUTO_CALL_SWITCH, useUnmergedTree = true)
+    val confirmTouchSwitch =
+        composeTestRule.onNodeWithTag(
+            DangerModeTestTags.CONFIRM_TOUCH_SWITCH, useUnmergedTree = true)
+    val confirmVoiceSwitch =
+        composeTestRule.onNodeWithTag(
+            DangerModeTestTags.CONFIRM_VOICE_SWITCH, useUnmergedTree = true)
+
+    // Initial state: all off
+    autoActionsSwitch.assertIsOff()
+    confirmTouchSwitch.assertIsOff()
+    confirmVoiceSwitch.assertIsOff()
+    assert(!viewModel.autoActionsEnabled.value)
+    assert(!viewModel.confirmTouchRequired.value)
+    assert(!viewModel.confirmVoiceRequired.value)
+
+    // Toggle auto actions
+    autoActionsSwitch.performClick()
+    autoActionsSwitch.assertIsOn()
+    assert(viewModel.autoActionsEnabled.value)
+    // Confirm others are still independent
+    assert(!viewModel.confirmTouchRequired.value)
+    assert(!viewModel.confirmVoiceRequired.value)
+
+    // Toggle touch confirmation
+    confirmTouchSwitch.performClick()
+    confirmTouchSwitch.assertIsOn()
+    assert(viewModel.confirmTouchRequired.value)
+
+    // Toggle voice confirmation
+    confirmVoiceSwitch.performClick()
+    confirmVoiceSwitch.assertIsOn()
+    assert(viewModel.confirmVoiceRequired.value)
+  }
 }

--- a/app/src/main/java/com/github/warnastrophy/core/data/service/DangerModeService.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/data/service/DangerModeService.kt
@@ -113,7 +113,6 @@ class DangerModeService(
 
       val requiredPermission =
           when (cap) {
-            DangerModeCapability.LOCATION -> AppPermissions.LocationFine
             DangerModeCapability.SMS -> AppPermissions.SendEmergencySms
             DangerModeCapability.CALL -> null
           }

--- a/app/src/main/java/com/github/warnastrophy/core/data/service/DangerModeService.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/data/service/DangerModeService.kt
@@ -111,11 +111,6 @@ class DangerModeService(
 
     for (cap in capabilities) {
 
-      // CALL capability is not supported yet
-      if (cap == DangerModeCapability.CALL) {
-        return Result.failure(IllegalStateException("CALL capability is not supported yet."))
-      }
-
       val requiredPermission =
           when (cap) {
             DangerModeCapability.LOCATION -> AppPermissions.LocationFine

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCard.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCard.kt
@@ -59,10 +59,10 @@ object DangerModeTestTags {
   const val COLOR_BOX_PREFIX = "dangerModeColorBox"
 
   const val ADVANCED_SECTION = "dangerModeAdvancedSection"
-  const val AUTO_CALL_SWITCH = "dangerModeAutoCallSwitch"
-  const val AUTO_MESSAGE_SWITCH = "dangerModeAutoMessageSwitch"
   const val CONFIRM_TOUCH_SWITCH = "dangerModeConfirmTouchSwitch"
   const val CONFIRM_VOICE_SWITCH = "dangerModeConfirmVoiceSwitch"
+
+  const val AUTO_CALL_SWITCH = "dangerModeAutoActionsSwitch"
 
   fun capabilityTag(capability: DangerModeCapability) = CAPABILITY_PREFIX + capability.label
 
@@ -91,6 +91,7 @@ fun DangerModeCard(
   val currentModeName by viewModel.currentMode.collectAsState(DangerModePreset.DEFAULT_MODE)
   val capabilities by viewModel.capabilities.collectAsState(emptySet())
   val dangerLevel by viewModel.dangerLevel.collectAsState(DangerLevel.LOW)
+  val autoActionsEnabled by viewModel.autoActionsEnabled.collectAsState(false)
 
   val confirmTouchRequired by viewModel.confirmTouchRequired.collectAsState(false)
   val confirmVoiceRequired by viewModel.confirmVoiceRequired.collectAsState(false)
@@ -214,14 +215,16 @@ fun DangerModeCard(
               }
             }
           }
-      if (capabilities.contains(DangerModeCapability.CALL)) {
+      if (capabilities.contains(DangerModeCapability.CALL) ||
+          capabilities.contains(DangerModeCapability.SMS)) {
         Spacer(modifier = Modifier.height(12.dp))
         DangerModeAdvancedOptionsSection(
+            autoActionsEnabled = autoActionsEnabled,
             confirmTouchRequired = confirmTouchRequired,
             confirmVoiceRequired = confirmVoiceRequired,
+            onAutoActionsChanged = viewModel::onAutoActionsEnabled,
             onConfirmTouchChanged = viewModel::onConfirmTouchChanged,
-            onConfirmVoiceChanged = viewModel::onConfirmVoiceChanged,
-        )
+            onConfirmVoiceChanged = viewModel::onConfirmVoiceChanged)
       }
 
       Spacer(modifier = Modifier.height(4.dp))
@@ -255,8 +258,10 @@ private fun DangerColorBox(
 
 @Composable
 private fun DangerModeAdvancedOptionsSection(
+    autoActionsEnabled: Boolean,
     confirmTouchRequired: Boolean,
     confirmVoiceRequired: Boolean,
+    onAutoActionsChanged: (Boolean) -> Unit,
     onConfirmTouchChanged: (Boolean) -> Unit,
     onConfirmVoiceChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier
@@ -264,11 +269,18 @@ private fun DangerModeAdvancedOptionsSection(
   val colors = MaterialTheme.colorScheme
 
   Column(modifier = modifier.fillMaxWidth().testTag(DangerModeTestTags.ADVANCED_SECTION)) {
-    Text(
-        text = "Automatic actions",
-        color = colors.onError,
-        fontSize = 13.sp,
-        fontWeight = FontWeight.SemiBold)
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+      Text(
+          text = "Automatic actions",
+          color = colors.onError,
+          fontSize = 13.sp,
+          fontWeight = FontWeight.SemiBold,
+          modifier = Modifier.weight(1f))
+      Switch(
+          checked = autoActionsEnabled,
+          onCheckedChange = onAutoActionsChanged,
+          modifier = Modifier.testTag(DangerModeTestTags.AUTO_CALL_SWITCH))
+    }
     Spacer(modifier = Modifier.height(4.dp))
     Text(
         text =

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCard.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCard.kt
@@ -58,6 +58,12 @@ object DangerModeTestTags {
   const val MODE_PREFIX = "dangerModePresetButton"
   const val COLOR_BOX_PREFIX = "dangerModeColorBox"
 
+    const val ADVANCED_SECTION = "dangerModeAdvancedSection"
+    const val AUTO_CALL_SWITCH = "dangerModeAutoCallSwitch"
+    const val AUTO_MESSAGE_SWITCH = "dangerModeAutoMessageSwitch"
+    const val CONFIRM_TOUCH_SWITCH = "dangerModeConfirmTouchSwitch"
+    const val CONFIRM_VOICE_SWITCH = "dangerModeConfirmVoiceSwitch"
+
   fun capabilityTag(capability: DangerModeCapability) = CAPABILITY_PREFIX + capability.label
 
   fun modeTag(mode: DangerModePreset) = MODE_PREFIX + mode.label
@@ -85,6 +91,10 @@ fun DangerModeCard(
   val currentModeName by viewModel.currentMode.collectAsState(DangerModePreset.DEFAULT_MODE)
   val capabilities by viewModel.capabilities.collectAsState(emptySet())
   val dangerLevel by viewModel.dangerLevel.collectAsState(DangerLevel.LOW)
+
+    val confirmTouchRequired by viewModel.confirmTouchRequired.collectAsState(false)
+    val confirmVoiceRequired by viewModel.confirmVoiceRequired.collectAsState(false)
+
   val colorScheme = MaterialTheme.colorScheme
   val extendedColors = MaterialTheme.extendedColors
 
@@ -204,6 +214,16 @@ fun DangerModeCard(
               }
             }
           }
+        if (capabilities.contains(DangerModeCapability.CALL)) {
+            Spacer(modifier = Modifier.height(12.dp))
+            DangerModeAdvancedOptionsSection(
+                confirmTouchRequired = confirmTouchRequired,
+                confirmVoiceRequired = confirmVoiceRequired,
+                onConfirmTouchChanged = viewModel::onConfirmTouchChanged,
+                onConfirmVoiceChanged = viewModel::onConfirmVoiceChanged,
+            )
+        }
+
       Spacer(modifier = Modifier.height(4.dp))
     }
   }
@@ -231,6 +251,83 @@ private fun DangerColorBox(
       modifier = modifier.size(width = 28.dp, height = 28.dp),
       border = BorderStroke(width = 2.dp, color = borderColor),
   ) {}
+}
+@Composable
+private fun DangerModeAdvancedOptionsSection(
+    confirmTouchRequired: Boolean,
+    confirmVoiceRequired: Boolean,
+    onConfirmTouchChanged: (Boolean) -> Unit,
+    onConfirmVoiceChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = MaterialTheme.colorScheme
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .testTag(DangerModeTestTags.ADVANCED_SECTION)) {
+        Text(
+            text = "Automatic actions",
+            color = colors.onError,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text =
+                "When Danger Mode is triggered, calls and messages can be sent automatically. " +
+                        "Use the options below to choose what happens, and how you confirm it.",
+            color = colors.onError.copy(alpha = 0.9f),
+            fontSize = 11.sp)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Confirmation methods",
+            color = colors.onError,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text =
+                "For extra control, you can require a quick confirmation before actions are sent.",
+            color = colors.onError.copy(alpha = 0.9f),
+            fontSize = 11.sp)
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // Tactile confirmation
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = "Require touch confirmation",
+                color = colors.onError,
+                fontSize = 13.sp,
+                modifier = Modifier.weight(1f))
+            Switch(
+                checked = confirmTouchRequired,
+                onCheckedChange = onConfirmTouchChanged,
+                modifier = Modifier.testTag(DangerModeTestTags.CONFIRM_TOUCH_SWITCH))
+        }
+
+        // Voice confirmation
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = "Allow voice confirmation",
+                color = colors.onError,
+                fontSize = 13.sp,
+                modifier = Modifier.weight(1f))
+            Switch(
+                checked = confirmVoiceRequired,
+                onCheckedChange = onConfirmVoiceChanged,
+                modifier = Modifier.testTag(DangerModeTestTags.CONFIRM_VOICE_SWITCH))
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCard.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCard.kt
@@ -58,11 +58,11 @@ object DangerModeTestTags {
   const val MODE_PREFIX = "dangerModePresetButton"
   const val COLOR_BOX_PREFIX = "dangerModeColorBox"
 
-    const val ADVANCED_SECTION = "dangerModeAdvancedSection"
-    const val AUTO_CALL_SWITCH = "dangerModeAutoCallSwitch"
-    const val AUTO_MESSAGE_SWITCH = "dangerModeAutoMessageSwitch"
-    const val CONFIRM_TOUCH_SWITCH = "dangerModeConfirmTouchSwitch"
-    const val CONFIRM_VOICE_SWITCH = "dangerModeConfirmVoiceSwitch"
+  const val ADVANCED_SECTION = "dangerModeAdvancedSection"
+  const val AUTO_CALL_SWITCH = "dangerModeAutoCallSwitch"
+  const val AUTO_MESSAGE_SWITCH = "dangerModeAutoMessageSwitch"
+  const val CONFIRM_TOUCH_SWITCH = "dangerModeConfirmTouchSwitch"
+  const val CONFIRM_VOICE_SWITCH = "dangerModeConfirmVoiceSwitch"
 
   fun capabilityTag(capability: DangerModeCapability) = CAPABILITY_PREFIX + capability.label
 
@@ -92,8 +92,8 @@ fun DangerModeCard(
   val capabilities by viewModel.capabilities.collectAsState(emptySet())
   val dangerLevel by viewModel.dangerLevel.collectAsState(DangerLevel.LOW)
 
-    val confirmTouchRequired by viewModel.confirmTouchRequired.collectAsState(false)
-    val confirmVoiceRequired by viewModel.confirmVoiceRequired.collectAsState(false)
+  val confirmTouchRequired by viewModel.confirmTouchRequired.collectAsState(false)
+  val confirmVoiceRequired by viewModel.confirmVoiceRequired.collectAsState(false)
 
   val colorScheme = MaterialTheme.colorScheme
   val extendedColors = MaterialTheme.extendedColors
@@ -214,15 +214,15 @@ fun DangerModeCard(
               }
             }
           }
-        if (capabilities.contains(DangerModeCapability.CALL)) {
-            Spacer(modifier = Modifier.height(12.dp))
-            DangerModeAdvancedOptionsSection(
-                confirmTouchRequired = confirmTouchRequired,
-                confirmVoiceRequired = confirmVoiceRequired,
-                onConfirmTouchChanged = viewModel::onConfirmTouchChanged,
-                onConfirmVoiceChanged = viewModel::onConfirmVoiceChanged,
-            )
-        }
+      if (capabilities.contains(DangerModeCapability.CALL)) {
+        Spacer(modifier = Modifier.height(12.dp))
+        DangerModeAdvancedOptionsSection(
+            confirmTouchRequired = confirmTouchRequired,
+            confirmVoiceRequired = confirmVoiceRequired,
+            onConfirmTouchChanged = viewModel::onConfirmTouchChanged,
+            onConfirmVoiceChanged = viewModel::onConfirmVoiceChanged,
+        )
+      }
 
       Spacer(modifier = Modifier.height(4.dp))
     }
@@ -252,6 +252,7 @@ private fun DangerColorBox(
       border = BorderStroke(width = 2.dp, color = borderColor),
   ) {}
 }
+
 @Composable
 private fun DangerModeAdvancedOptionsSection(
     confirmTouchRequired: Boolean,
@@ -260,74 +261,65 @@ private fun DangerModeAdvancedOptionsSection(
     onConfirmVoiceChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val colors = MaterialTheme.colorScheme
+  val colors = MaterialTheme.colorScheme
 
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .testTag(DangerModeTestTags.ADVANCED_SECTION)) {
-        Text(
-            text = "Automatic actions",
-            color = colors.onError,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.SemiBold)
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text =
-                "When Danger Mode is triggered, calls and messages can be sent automatically. " +
-                        "Use the options below to choose what happens, and how you confirm it.",
-            color = colors.onError.copy(alpha = 0.9f),
-            fontSize = 11.sp)
+  Column(modifier = modifier.fillMaxWidth().testTag(DangerModeTestTags.ADVANCED_SECTION)) {
+    Text(
+        text = "Automatic actions",
+        color = colors.onError,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold)
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text =
+            "When Danger Mode is triggered, calls and messages can be sent automatically. " +
+                "Use the options below to choose what happens, and how you confirm it.",
+        color = colors.onError.copy(alpha = 0.9f),
+        fontSize = 11.sp)
 
-        Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-        Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-        Text(
-            text = "Confirmation methods",
-            color = colors.onError,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.SemiBold)
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text =
-                "For extra control, you can require a quick confirmation before actions are sent.",
-            color = colors.onError.copy(alpha = 0.9f),
-            fontSize = 11.sp)
+    Text(
+        text = "Confirmation methods",
+        color = colors.onError,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold)
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = "For extra control, you can require a quick confirmation before actions are sent.",
+        color = colors.onError.copy(alpha = 0.9f),
+        fontSize = 11.sp)
 
-        Spacer(modifier = Modifier.height(6.dp))
+    Spacer(modifier = Modifier.height(6.dp))
 
-        // Tactile confirmation
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()) {
-            Text(
-                text = "Require touch confirmation",
-                color = colors.onError,
-                fontSize = 13.sp,
-                modifier = Modifier.weight(1f))
-            Switch(
-                checked = confirmTouchRequired,
-                onCheckedChange = onConfirmTouchChanged,
-                modifier = Modifier.testTag(DangerModeTestTags.CONFIRM_TOUCH_SWITCH))
-        }
-
-        // Voice confirmation
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()) {
-            Text(
-                text = "Allow voice confirmation",
-                color = colors.onError,
-                fontSize = 13.sp,
-                modifier = Modifier.weight(1f))
-            Switch(
-                checked = confirmVoiceRequired,
-                onCheckedChange = onConfirmVoiceChanged,
-                modifier = Modifier.testTag(DangerModeTestTags.CONFIRM_VOICE_SWITCH))
-        }
+    // Tactile confirmation
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+      Text(
+          text = "Require touch confirmation",
+          color = colors.onError,
+          fontSize = 13.sp,
+          modifier = Modifier.weight(1f))
+      Switch(
+          checked = confirmTouchRequired,
+          onCheckedChange = onConfirmTouchChanged,
+          modifier = Modifier.testTag(DangerModeTestTags.CONFIRM_TOUCH_SWITCH))
     }
+
+    // Voice confirmation
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+      Text(
+          text = "Allow voice confirmation",
+          color = colors.onError,
+          fontSize = 13.sp,
+          modifier = Modifier.weight(1f))
+      Switch(
+          checked = confirmVoiceRequired,
+          onCheckedChange = onConfirmVoiceChanged,
+          modifier = Modifier.testTag(DangerModeTestTags.CONFIRM_VOICE_SWITCH))
+    }
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
@@ -63,11 +63,11 @@ class DangerModeCardViewModel(
           .map { it.capabilities }
           .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
 
-    private val _confirmTouchRequired = MutableStateFlow(false)
-    val confirmTouchRequired: StateFlow<Boolean> = _confirmTouchRequired.asStateFlow()
+  private val _confirmTouchRequired = MutableStateFlow(false)
+  val confirmTouchRequired: StateFlow<Boolean> = _confirmTouchRequired.asStateFlow()
 
-    private val _confirmVoiceRequired = MutableStateFlow(false)
-    val confirmVoiceRequired: StateFlow<Boolean> = _confirmVoiceRequired.asStateFlow()
+  private val _confirmVoiceRequired = MutableStateFlow(false)
+  val confirmVoiceRequired: StateFlow<Boolean> = _confirmVoiceRequired.asStateFlow()
 
   /**
    * Handles the toggling of Danger Mode on or off and starts or stops the foreground GPS service
@@ -130,16 +130,16 @@ class DangerModeCardViewModel(
    * @param level The new danger level to be set.
    */
   fun onDangerLevelChanged(level: DangerLevel) {
-      dangerModeService.setDangerLevel(level)
+    dangerModeService.setDangerLevel(level)
   }
 
-    fun onConfirmTouchChanged(enabled: Boolean) {
-        _confirmTouchRequired.value = enabled
-        // TODO: Persist & enforce tactile confirmation before actions.
-    }
+  fun onConfirmTouchChanged(enabled: Boolean) {
+    _confirmTouchRequired.value = enabled
+    // TODO: Persist & enforce tactile confirmation before actions.
+  }
 
-    fun onConfirmVoiceChanged(enabled: Boolean) {
-        _confirmVoiceRequired.value = enabled
-        // TODO: Persist & enforce voice confirmation before actions.
-    }
+  fun onConfirmVoiceChanged(enabled: Boolean) {
+    _confirmVoiceRequired.value = enabled
+    // TODO: Persist & enforce voice confirmation before actions.
+  }
 }

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
@@ -8,7 +8,10 @@ import com.github.warnastrophy.core.data.service.DangerLevel
 import com.github.warnastrophy.core.data.service.StateManagerService
 import com.github.warnastrophy.core.domain.model.startForegroundGpsService
 import com.github.warnastrophy.core.domain.model.stopForegroundGpsService
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
@@ -59,6 +62,12 @@ class DangerModeCardViewModel(
       dangerModeService.state
           .map { it.capabilities }
           .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
+
+    private val _confirmTouchRequired = MutableStateFlow(false)
+    val confirmTouchRequired: StateFlow<Boolean> = _confirmTouchRequired.asStateFlow()
+
+    private val _confirmVoiceRequired = MutableStateFlow(false)
+    val confirmVoiceRequired: StateFlow<Boolean> = _confirmVoiceRequired.asStateFlow()
 
   /**
    * Handles the toggling of Danger Mode on or off and starts or stops the foreground GPS service
@@ -121,6 +130,16 @@ class DangerModeCardViewModel(
    * @param level The new danger level to be set.
    */
   fun onDangerLevelChanged(level: DangerLevel) {
-    dangerModeService.setDangerLevel(level)
+      dangerModeService.setDangerLevel(level)
   }
+
+    fun onConfirmTouchChanged(enabled: Boolean) {
+        _confirmTouchRequired.value = enabled
+        // TODO: Persist & enforce tactile confirmation before actions.
+    }
+
+    fun onConfirmVoiceChanged(enabled: Boolean) {
+        _confirmVoiceRequired.value = enabled
+        // TODO: Persist & enforce voice confirmation before actions.
+    }
 }

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.stateIn
 enum class DangerModeCapability(val label: String) {
   CALL("Call"),
   SMS("SMS"),
-  LOCATION("Location")
 }
 
 /** Preset modes for Danger Mode with associated labels. */
@@ -63,6 +62,8 @@ class DangerModeCardViewModel(
           .map { it.capabilities }
           .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
 
+  private val _autoActionsEnabled = MutableStateFlow(false)
+  val autoActionsEnabled: StateFlow<Boolean> = _autoActionsEnabled.asStateFlow()
   private val _confirmTouchRequired = MutableStateFlow(false)
   val confirmTouchRequired: StateFlow<Boolean> = _confirmTouchRequired.asStateFlow()
 
@@ -135,6 +136,11 @@ class DangerModeCardViewModel(
 
   fun onConfirmTouchChanged(enabled: Boolean) {
     _confirmTouchRequired.value = enabled
+    // TODO: Persist & enforce tactile confirmation before actions.
+  }
+
+  fun onAutoActionsEnabled(enabled: Boolean) {
+    _autoActionsEnabled.value = enabled
     // TODO: Persist & enforce tactile confirmation before actions.
   }
 

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/dashboard/DangerModeCardViewModel.kt
@@ -64,10 +64,16 @@ class DangerModeCardViewModel(
 
   private val _autoActionsEnabled = MutableStateFlow(false)
   val autoActionsEnabled: StateFlow<Boolean> = _autoActionsEnabled.asStateFlow()
-  private val _confirmTouchRequired = MutableStateFlow(false)
+  private val _confirmTouchRequired =
+      MutableStateFlow(
+          false) // This is tactile confirmation before the app takes actions like calling/emergency
+  // SMS
   val confirmTouchRequired: StateFlow<Boolean> = _confirmTouchRequired.asStateFlow()
 
-  private val _confirmVoiceRequired = MutableStateFlow(false)
+  private val _confirmVoiceRequired =
+      MutableStateFlow(
+          false) // This is audio confirmation before the app takes actions like calling/emergency
+  // SMS
   val confirmVoiceRequired: StateFlow<Boolean> = _confirmVoiceRequired.asStateFlow()
 
   /**

--- a/app/src/test/java/com/github/warnastrophy/core/data/service/DangerModeServiceTest.kt
+++ b/app/src/test/java/com/github/warnastrophy/core/data/service/DangerModeServiceTest.kt
@@ -74,7 +74,7 @@ class DangerModeServiceTest {
     service.setPreset(DangerModePreset.CLIMBING_MODE)
     assertEquals(DangerModePreset.CLIMBING_MODE, service.state.value.preset)
 
-    val capabilities = setOf(DangerModeCapability.LOCATION)
+    val capabilities = setOf(DangerModeCapability.SMS)
     service.setCapabilities(capabilities)
 
     assertEquals(capabilities, service.state.value.capabilities)
@@ -184,7 +184,7 @@ class DangerModeServiceTest {
     val (service, _) = createService(permissionManager = fakePm)
 
     service.setPreset(DangerModePreset.HIKING_MODE)
-    val caps = setOf(DangerModeCapability.LOCATION)
+    val caps = setOf(DangerModeCapability.SMS)
     service.setCapabilities(caps)
 
     service.setDangerLevel(DangerLevel.CRITICAL) // coerced to 3
@@ -275,21 +275,6 @@ class DangerModeServiceTest {
   }
 
   /**
-   * Verifies that the CALL capability is always rejected. This capability is intentionally
-   * unsupported and must never appear in the state.
-   */
-  @Test
-  fun call_capability_is_always_rejected() = runTest {
-    val pm = PermissionManagerMock(PermissionResult.Granted)
-    val (service, _) = createService(permissionManager = pm)
-
-    val result = service.setCapabilities(setOf(DangerModeCapability.CALL))
-
-    assertTrue(result.isFailure)
-    assertTrue(service.state.value.capabilities.isEmpty())
-  }
-
-  /**
    * Confirms that manual activation works even when SMS permission is missing. Danger Mode should
    * activate normally and no error event should be emitted.
    */
@@ -333,7 +318,7 @@ class DangerModeServiceTest {
     val pm = PermissionManagerMock(PermissionResult.Denied(listOf("fine_location")))
     val (service, _) = createService(permissionManager = pm)
 
-    val result = service.setCapabilities(setOf(DangerModeCapability.LOCATION))
+    val result = service.setCapabilities(setOf(DangerModeCapability.SMS))
 
     assertTrue(result.isFailure)
     assertTrue(service.state.value.capabilities.isEmpty())
@@ -348,9 +333,9 @@ class DangerModeServiceTest {
     val pm = PermissionManagerMock(PermissionResult.Granted)
     val (service, _) = createService(permissionManager = pm)
 
-    val result = service.setCapabilities(setOf(DangerModeCapability.LOCATION))
+    val result = service.setCapabilities(setOf(DangerModeCapability.SMS))
 
     assertTrue(result.isSuccess)
-    assertEquals(setOf(DangerModeCapability.LOCATION), service.state.value.capabilities)
+    assertEquals(setOf(DangerModeCapability.SMS), service.state.value.capabilities)
   }
 }


### PR DESCRIPTION
This PR is linked to the issue #245.

### Summary
This PR introduces more dangerMode options such as "Require touch confirmation" and "Allow voice confirmation". These options show after the user has selected either Call or SMS contact options in the DangerMode card in the dashboard. 

### What changed?
- The "Location" option is no longer shown in the DangerMode Card since it is embedded in the Call and SMS options already (the app sends the user's location to the emergency contact)
- There is a switch toggle beside the "Automatic Actions" that allows the user to select the automatic contact options

### Testing
- I added some tests in the DangerModeCardTest file to cover these new functionalities
- I modified the tests in DangerModeService that still referenced the now-removed "Location" button