### PR TITLE
fix: sonarcloud warning memory leak

### DIFF
--- a/app/src/main/java/com/github/warnastrophy/core/permissions/PermissionManager.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/permissions/PermissionManager.kt
@@ -102,17 +102,6 @@ interface PermissionManagerInterface {
 class PermissionManager(private val context: Context) : PermissionManagerInterface {
   private val prefs = context.getSharedPreferences(AppConfig.PREF_FILE_NAME, Context.MODE_PRIVATE)
 
-  companion object {
-    @Volatile private var instance: PermissionManager? = null
-
-    fun getInstance(context: Context): PermissionManager {
-      return instance
-          ?: synchronized(this) {
-            instance ?: PermissionManager(context.applicationContext).also { instance = it }
-          }
-    }
-  }
-
   override fun getPermissionResult(permissionType: AppPermissions): PermissionResult {
     val permissions = permissionType.permissions
     if (permissions.isEmpty()) return PermissionResult.Granted


### PR DESCRIPTION
This PR is linked to the issue #212 

### Summary
This is a very small PR where I "fix" the issue about the memory leak caused by a Context class referecing Context, by simply removing is since the function "getInstance" is never used for PermissionManager. I believe I had added it for testing purposes but ended up not needing it and forgot to remove it.