### PR TITLE
feature:remove useless information from hazardmarker and add info and…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -208,6 +208,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+    implementation("io.coil-kt:coil-compose:2.7.0")
     implementation(libs.material)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -208,7 +208,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation("io.coil-kt:coil-compose:2.7.0")
+    implementation(libs.coil.compose)
     implementation(libs.material)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))

--- a/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/HazardUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/HazardUtilsTest.kt
@@ -1,0 +1,119 @@
+package com.github.warnastrophy.core.ui.features.map
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import com.github.warnastrophy.R
+import com.github.warnastrophy.core.model.Hazard
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class HazardUtilsTest {
+  private fun baseHazard() =
+      Hazard(
+          id = 0,
+          type = "FL",
+          description = "Flood",
+          country = null,
+          date = null,
+          severity = null,
+          severityUnit = null,
+          articleUrl = null,
+          alertLevel = null,
+          bbox = null,
+          affectedZone = null,
+          centroid = null)
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    MapsInitializer.initialize(context)
+  }
+
+  @Test
+  fun formatSeveritySnippet_handlesNullZeroAndPositive() {
+    val hNull = baseHazard()
+    val hZero = baseHazard().copy(severity = 0.0, severityUnit = "mm")
+    val hInt = baseHazard().copy(severity = 10.0, severityUnit = "mm")
+    val hFloat = baseHazard().copy(severity = 12.5, severityUnit = "")
+
+    assertNull(formatSeveritySnippet(hNull))
+    assertNull(formatSeveritySnippet(hZero))
+    assertEquals("10 mm", formatSeveritySnippet(hInt))
+    assertEquals("12.5", formatSeveritySnippet(hFloat))
+  }
+
+  @Test
+  fun hazardTypeToMapIcon_andDrawableRes_coverAllBranches() {
+    assertEquals(MapIcon.Flood, hazardTypeToMapIcon("FL"))
+    assertEquals(MapIcon.Drought, hazardTypeToMapIcon("DR"))
+    assertEquals(MapIcon.Earthquake, hazardTypeToMapIcon("EQ"))
+    assertEquals(MapIcon.Cyclone, hazardTypeToMapIcon("TC"))
+    assertEquals(MapIcon.Fire, hazardTypeToMapIcon("FR"))
+    assertEquals(MapIcon.Volcano, hazardTypeToMapIcon("VO"))
+    assertEquals(MapIcon.Tsunami, hazardTypeToMapIcon("TS"))
+    assertEquals(MapIcon.Unknown, hazardTypeToMapIcon("XX"))
+    assertEquals(MapIcon.Unknown, hazardTypeToMapIcon(null))
+
+    assertEquals(R.drawable.material_symbols_outlined_flood, hazardTypeToDrawableRes("FL"))
+    assertEquals(R.drawable.material_symbols_outlined_water_voc, hazardTypeToDrawableRes("DR"))
+    assertEquals(R.drawable.material_symbols_outlined_earthquake, hazardTypeToDrawableRes("EQ"))
+    assertEquals(R.drawable.material_symbols_outlined_storm, hazardTypeToDrawableRes("TC"))
+    assertEquals(
+        R.drawable.material_symbols_outlined_local_fire_department, hazardTypeToDrawableRes("FR"))
+    assertEquals(R.drawable.material_symbols_outlined_volcano, hazardTypeToDrawableRes("VO"))
+    assertEquals(R.drawable.material_symbols_outlined_tsunami, hazardTypeToDrawableRes("TS"))
+    assertNull(hazardTypeToDrawableRes("XX"))
+    assertNull(hazardTypeToDrawableRes(null))
+  }
+
+  @Test
+  fun computeSeverityTint_respectsMinMaxAndNulls() {
+    val hazardBase = baseHazard().copy(type = "X", severity = 5.0)
+    val severities = mapOf("X" to (0.0 to 10.0))
+
+    val mid = computeSeverityTint(hazardBase, severities)
+    // Midway between Gray and Red: just assert it’s “not black”
+    assertTrue(mid != Color.Black)
+
+    val hazardLow = hazardBase.copy(severity = 0.0)
+    val hazardHigh = hazardBase.copy(severity = 10.0)
+    val low = computeSeverityTint(hazardLow, severities)
+    val high = computeSeverityTint(hazardHigh, severities)
+
+    val lowGray = (low.red + low.green + low.blue) / 3f
+    val highGray = (high.red + high.green + high.blue) / 3f
+    assertTrue(highGray < lowGray)
+
+    // severity == null -> Color.Black
+    val hazardNull = hazardBase.copy(severity = null)
+    val nullColor = computeSeverityTint(hazardNull, severities)
+    assertEquals(Color.Black, nullColor)
+
+    // type == null -> Color.Black
+    val hazardNoType = hazardBase.copy(type = null, severity = 5.0)
+    val noTypeColor = computeSeverityTint(hazardNoType, severities)
+    assertEquals(Color.Black, noTypeColor)
+  }
+
+  @Test
+  fun bitmapDescriptorFromVector_createsBitmapAndAppliesTint() {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    val descriptor =
+        bitmapDescriptorFromVector(
+            context = context,
+            vectorResId = R.drawable.material_symbols_outlined_flood,
+            sizeDp = 32f,
+            tintColor = Color.Red)
+
+    // We can't inspect the pixels easily here,
+    // but we can assert that it's not the default marker.
+    // (Default marker has a fixed hue; this at least executes all lines.)
+    assertTrue(descriptor != BitmapDescriptorFactory.defaultMarker())
+  }
+}

--- a/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/MapIconTest.kt
+++ b/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/MapIconTest.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import com.github.warnastrophy.core.model.Hazard
 import com.github.warnastrophy.core.util.BaseAndroidComposeTest
+import com.github.warnastrophy.core.util.formatDate
+import com.google.maps.android.compose.MarkerState
 import junit.framework.TestCase
 import org.junit.Test
 
@@ -132,5 +137,223 @@ class MapIconTest : BaseAndroidComposeTest() {
         affectedZone = null,
         alertLevel = null,
         centroid = null)
+  }
+
+  @Test
+  fun formatSeveritySnippet_hidesZeroAndNull() {
+    // severity == null -> no snippet
+    val hazardNullSeverity =
+        Hazard(
+            id = 1,
+            type = "FL",
+            description = "Flood",
+            country = null,
+            date = null,
+            severity = null,
+            severityUnit = "ha",
+            articleUrl = null,
+            alertLevel = null,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    // severity == 0.0 -> no snippet (non-meaningful)
+    val hazardZeroSeverity = hazardNullSeverity.copy(id = 2, severity = 0.0)
+
+    // severity > 0 with unit
+    val hazardPositiveWithUnit =
+        hazardNullSeverity.copy(id = 3, severity = 1234.0, severityUnit = "ha")
+
+    // severity > 0 without unit
+    val hazardPositiveNoUnit = hazardNullSeverity.copy(id = 4, severity = 12.5, severityUnit = null)
+
+    // Null + 0.0 should give null snippet
+    TestCase.assertNull(formatSeveritySnippet(hazardNullSeverity))
+    TestCase.assertNull(formatSeveritySnippet(hazardZeroSeverity))
+
+    // Positive with unit
+    val snippetWithUnit = formatSeveritySnippet(hazardPositiveWithUnit)
+    TestCase.assertEquals("1234 ha", snippetWithUnit)
+
+    // Positive without unit (keeps decimal with one digit)
+    val snippetNoUnit = formatSeveritySnippet(hazardPositiveNoUnit)
+    TestCase.assertEquals("12.5", snippetNoUnit)
+  }
+
+  @Test
+  fun hazardInfoWindowContent_showsMeaningfulData_andArticleHint() {
+    val hazard =
+        Hazard(
+            id = 10,
+            type = "FR",
+            description = "Wildfire in Region X",
+            country = "CountryY",
+            date = "2025-07-15",
+            severity = 13590.0,
+            severityUnit = "ha",
+            articleUrl = "https://example.com/news/fire",
+            alertLevel = 3.0,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    val snippet = formatSeveritySnippet(hazard)
+    composeTestRule.setContent {
+      HazardInfoWindowContent(
+          hazard = hazard,
+          title = hazard.description,
+          snippet = snippet,
+      )
+    }
+
+    // Description / title
+    composeTestRule.onNodeWithText("Wildfire in Region X").assertIsDisplayed()
+
+    // Severity text (from snippet) -- "13590 ha"
+    composeTestRule.onNodeWithText("13590 ha").assertIsDisplayed()
+
+    // Optional severityText: not set here, so we don't assert it
+
+    // Date (formatted). We don't assert exact format, just that some date-like text exists.
+    // If you know the exact output of formatDate("2025-07-15"), you can assert that instead.
+    val formattedDate = formatDate("2025-07-15")
+    composeTestRule.onNodeWithText(formattedDate).assertIsDisplayed()
+
+    // Hint for article URL
+    composeTestRule
+        .onNodeWithText("Tap this bubble to open the full news article")
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun hazardMarker_doesNotShowZeroSeveritySnippet() {
+    val hazard =
+        Hazard(
+            id = 42,
+            type = "FL",
+            description = "Minor flood",
+            country = null,
+            date = null,
+            severity = 0.0, // non-meaningful → snippet must be hidden
+            severityUnit = "ha",
+            severityText = null,
+            articleUrl = "https://example.com/flood",
+            alertLevel = null,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    // Must contain an entry for the hazard type, otherwise computeSeverityTint() throws
+    val severities = mapOf("FL" to (0.0 to 10.0))
+
+    composeTestRule.setContent {
+      HazardMarker(
+          hazard = hazard,
+          severities = severities,
+          markerContent = { _, title, snippet, _ ->
+            HazardInfoWindowContent(
+                hazard = hazard,
+                title = title,
+                snippet = snippet,
+            )
+          })
+    }
+
+    // Title is visible
+    composeTestRule.onNodeWithText("Minor flood").assertIsDisplayed()
+    // "0.0" must NOT appear anywhere
+    composeTestRule.onAllNodesWithText("0.0").assertCountEquals(0)
+  }
+
+  @Test
+  fun hazardMarker_passesLocationTitleSnippetAndTintToMarkerContent() {
+    val hazard =
+        Hazard(
+            id = 1,
+            type = "XX",
+            description = "Test hazard",
+            country = null,
+            date = null,
+            severity = 5.0,
+            severityUnit = "units",
+            articleUrl = null,
+            alertLevel = null,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    val severities = mapOf("XX" to (1.0 to 9.0))
+
+    // capture what markerContent receives
+    lateinit var receivedState: MarkerState
+    var receivedTitle: String? = null
+    var receivedSnippet: String? = null
+
+    composeTestRule.setContent {
+      HazardMarker(
+          hazard = hazard,
+          severities = severities,
+          markerContent = { state, title, snippet, content ->
+            receivedState = state
+            receivedTitle = title
+            receivedSnippet = snippet
+            Box { content() }
+          })
+    }
+
+    composeTestRule.waitForIdle()
+
+    // 2) Title and snippet are passed
+    TestCase.assertEquals("Test hazard", receivedTitle)
+    TestCase.assertEquals("5 units", receivedSnippet)
+
+    // 3) Icon composable is rendered with a Tint semantics; we use the Unknown tag
+    val node = composeTestRule.onNodeWithTag(MapIcon.Unknown.tag)
+    node.assertIsDisplayed()
+    val tintColor = node.fetchSemanticsNode().config.getOrNull(Tint)
+    TestCase.assertNotNull(tintColor)
+  }
+
+  @Test
+  fun hazardInfoWindowContent_showsDescriptionSeverityDateAndHint() {
+    val hazard =
+        Hazard(
+            id = 99,
+            type = "FR",
+            description = "Wildfire in Region X",
+            country = "CountryY",
+            date = "2025-07-15",
+            severity = 13590.0,
+            severityUnit = "ha",
+            articleUrl = "https://example.com/news/fire",
+            alertLevel = 3.0,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    val snippet = formatSeveritySnippet(hazard)
+
+    composeTestRule.setContent {
+      HazardInfoWindowContent(
+          hazard = hazard,
+          title = hazard.description,
+          snippet = snippet,
+      )
+    }
+
+    // Title
+    composeTestRule.onNodeWithText("Wildfire in Region X").assertIsDisplayed()
+
+    // Severity snippet
+    composeTestRule.onNodeWithText("13590 ha").assertIsDisplayed()
+
+    // Date (formatted)
+    val formattedDate = formatDate("2025-07-15")
+    composeTestRule.onNodeWithText(formattedDate).assertIsDisplayed()
+
+    // Article hint
+    composeTestRule
+        .onNodeWithText("Tap this bubble to open the full news article")
+        .assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/MapScreenTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Build
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
@@ -24,6 +25,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
@@ -31,6 +33,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.github.warnastrophy.core.data.repository.GeocodeRepository
 import com.github.warnastrophy.core.data.repository.MockNominatimRepository
 import com.github.warnastrophy.core.data.service.MockNominatimService
+import com.github.warnastrophy.core.model.Hazard
 import com.github.warnastrophy.core.permissions.AppPermissions
 import com.github.warnastrophy.core.permissions.PermissionResult
 import com.github.warnastrophy.core.ui.components.FALLBACK_ACTIVITY_ERROR
@@ -441,5 +444,39 @@ class MapScreenTest : BaseAndroidComposeTest() {
               ?: ""
       Assert.assertEquals(hardcodedlocs[i].name, nodeText)
     }
+  }
+
+  @Test
+  fun openHazardArticle_handlesNullAndValidUrl() {
+    val context = composeTestRule.activity
+
+    // Null URL → no crash
+    openHazardArticle(context, null)
+
+    // Valid URL → should attempt to startActivity, but we just verify it doesn't crash.
+    openHazardArticle(context, "https://example.com/news")
+  }
+
+  @Test
+  fun hazardNewsImage_usesAsyncImage_whenUrlLooksLikeImage() {
+    val hazard =
+        Hazard(
+            id = 123,
+            type = "FR",
+            description = "Fire with image",
+            country = null,
+            date = null,
+            severity = null,
+            severityUnit = null,
+            articleUrl = "https://example.com/image.jpg", // triggers AsyncImage path
+            alertLevel = null,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    composeTestRule.setContent { HazardNewsImage(hazard = hazard, modifier = Modifier.size(48.dp)) }
+
+    // We don’t have a direct tag, but rendering without crash covers all lines
+    composeTestRule.waitForIdle()
   }
 }

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/map/MapIcon.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/map/MapIcon.kt
@@ -1,6 +1,5 @@
 package com.github.warnastrophy.core.ui.features.map
 
-import android.R.attr.type
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -267,11 +266,12 @@ fun formatSeveritySnippet(hazard: Hazard): String? {
   return if (unit.isNotEmpty()) "$rounded $unit" else rounded
 }
 
-/*
-This function opens a hazard article URL in the device's default web browser.
-  If the URL is null, the function does nothing.
-  @param context The context used to start the activity.
-  @param articleUrl The URL of the hazard article to open.
+/**
+ * This function opens a hazard article URL in the device's default web browser. If the URL is null,
+ * the function does nothing.
+ *
+ * @param context The context used to start the activity.
+ * @param articleUrl The URL of the hazard article to open.
  */
 fun openHazardArticle(context: Context, articleUrl: String?) {
   articleUrl ?: return

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/map/MapIcon.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/map/MapIcon.kt
@@ -102,10 +102,7 @@ enum class MapIcon(@DrawableRes val resId: Int?, val tag: String) {
 
 val LocalOnHazardClick = staticCompositionLocalOf<(Hazard) -> Unit> { {} }
 
-private fun computeSeverityTint(
-    hazard: Hazard,
-    severities: Map<String, Pair<Double, Double>>
-): Color {
+fun computeSeverityTint(hazard: Hazard, severities: Map<String, Pair<Double, Double>>): Color {
   val severity = hazard.severity ?: return Color.Black
   val type = hazard.type ?: return Color.Black
 
@@ -196,7 +193,7 @@ fun HazardMarker(
   }
 }
 
-private fun hazardTypeToDrawableRes(type: String?): Int? =
+fun hazardTypeToDrawableRes(type: String?): Int? =
     when (type) {
       "FL",
       "FF",
@@ -218,7 +215,7 @@ private fun hazardTypeToDrawableRes(type: String?): Int? =
       else -> null
     }
 
-private fun hazardTypeToMapIcon(type: String?): MapIcon =
+fun hazardTypeToMapIcon(type: String?): MapIcon =
     when (type) {
       "FL",
       "FF",
@@ -240,7 +237,7 @@ private fun hazardTypeToMapIcon(type: String?): MapIcon =
       else -> MapIcon.Unknown
     }
 
-private fun formatSeveritySnippet(hazard: Hazard): String? {
+fun formatSeveritySnippet(hazard: Hazard): String? {
   val value = hazard.severity ?: return null
   if (value == 0.0) return null
 
@@ -251,7 +248,7 @@ private fun formatSeveritySnippet(hazard: Hazard): String? {
   return if (unit.isNotEmpty()) "$rounded $unit" else rounded
 }
 
-private fun openHazardArticle(context: Context, articleUrl: String?) {
+fun openHazardArticle(context: Context, articleUrl: String?) {
   articleUrl ?: return
   val intent = Intent(Intent.ACTION_VIEW, Uri.parse(articleUrl))
   ContextCompat.startActivity(context, intent, null)
@@ -326,7 +323,7 @@ fun HazardNewsImage(hazard: Hazard, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun HazardInfoWindowContent(
+fun HazardInfoWindowContent(
     hazard: Hazard,
     title: String?,
     snippet: String?,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="health_card_screen_title">Emergency Card</string>
     <string name="sign_in_title">Sign In</string>
     <string name="default_web_client_id">327661063729-5v74bg67jtne1ol3t7oinv04i94og11i.apps.googleusercontent.com</string>
+    <string name="open_article_link">Tap this bubble to open the full news article</string>
 
     <!-- Dashboard Strings -->
     <string name="latest_news">Latest news</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jtsCore = "1.20.0"
 kotlin = "1.9.24"
 coreKtx = "1.12.0"
 kotlinxCoroutinesTest = "1.9.0"
+coil = "2.7.0"
 kotlinxCoroutinesTestVersion = "1.8.1"
 ktfmt = "0.17.0"
 junit = "4.13.2"
@@ -79,7 +80,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
This PR is linked to the issue #271

### Summary
This PR implements a customized card to display the Hazard Information briefly in the Map. It displays more relevant and precise information in the card, as well as an image of the hazard (like an icon but more representative). 

### What changed?
- I used the StandardDashboardCard to make the card more in tune with our app's theme
- I made several helper functions to display the image in the card and to add the severity colors
- When the hazard comes from an available news source, the URL of that news article will be included in the card

Tha functionality is used in the same way, such that when you click on the hazard's icon on the map, the card appears and displays the information.

### Testing
- I added a test file for HazardUtilsTest file to test the helper functions I made for the HazardMarker
- I also added test in the MapIconTest file to test the new functionality

<img width="230" height="600" alt="image" src="https://github.com/user-attachments/assets/c13859af-2273-429c-a424-ad20f5cf4b39" />
