### PR TITLE
Display affected area only for selected hazard marker

### DIFF
--- a/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/MapIconTest.kt
+++ b/app/src/androidTest/java/com/github/warnastrophy/core/ui/features/map/MapIconTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
@@ -16,6 +17,7 @@ import androidx.compose.ui.test.onNodeWithText
 import com.github.warnastrophy.core.model.Hazard
 import com.github.warnastrophy.core.util.BaseAndroidComposeTest
 import com.github.warnastrophy.core.util.formatDate
+import com.google.android.gms.maps.model.LatLng
 import junit.framework.TestCase
 import org.junit.Test
 
@@ -64,7 +66,12 @@ class MapIconTest : BaseAndroidComposeTest() {
 
     composeTestRule.setContent {
       hazard.value?.let {
-        HazardMarker(it, markerContent = { _, _, _, _, _, content -> Box { content() } })
+        HazardMarker(
+            it,
+            markerIconProvider = { _, _, _, _ -> null },
+            polygonContent = {},
+            markerInfoWindowContent = { _, _, _, _, content -> Box { content() } },
+            iconContent = { icon, tint -> icon(tint) })
       }
     }
 
@@ -198,13 +205,10 @@ class MapIconTest : BaseAndroidComposeTest() {
     composeTestRule.setContent {
       HazardMarker(
           hazard = hazard,
-          markerContent = { _, title, snippet, _, _, _ ->
-            HazardInfoWindowContent(
-                hazard = hazard,
-                title = title,
-                snippet = snippet,
-            )
-          })
+          markerIconProvider = { _, _, _, _ -> null },
+          polygonContent = {},
+          markerInfoWindowContent = { _, _, _, _, content -> Box { content() } },
+          iconContent = { _, _ -> })
     }
 
     // Title is visible
@@ -214,7 +218,7 @@ class MapIconTest : BaseAndroidComposeTest() {
   }
 
   @Test
-  fun hazardMarker_passesLocationTitleSnippetAndTintToMarkerContent() {
+  fun hazardMarker_passesIconAndTintToIconContent() {
     val hazard =
         Hazard(
             id = 1,
@@ -230,27 +234,31 @@ class MapIconTest : BaseAndroidComposeTest() {
             affectedZone = null,
             centroid = null)
 
-    // capture what markerContent receives
-    var receivedTitle: String? = null
-    var receivedSnippet: String? = null
+    // capture what iconContent receives
+    var receivedIcon: MapIcon? = null
+    var receivedTint: Color? = null
 
     composeTestRule.setContent {
       HazardMarker(
           hazard = hazard,
-          markerContent = { _, title, snippet, _, _, content ->
-            receivedTitle = title
-            receivedSnippet = snippet
-            Box { content() }
+          markerIconProvider = { _, _, _, _ -> null },
+          polygonContent = {},
+          markerInfoWindowContent = { _, _, _, _, content -> Box { content() } },
+          iconContent = { icon, tint ->
+            receivedIcon = icon
+            receivedTint = tint
+            icon(tint)
           })
     }
 
     composeTestRule.waitForIdle()
 
-    // 2) Title and snippet are passed
-    TestCase.assertEquals("Test hazard", receivedTitle)
-    TestCase.assertEquals("5 units", receivedSnippet)
+    // Icon is Unknown for type "XX"
+    TestCase.assertEquals(MapIcon.Unknown, receivedIcon)
+    // Tint color should be UNKNOWN (gray) since alertLevel is null
+    TestCase.assertEquals(SeverityColors.UNKNOWN, receivedTint)
 
-    // 3) Icon composable is rendered with a Tint semantics; we use the Unknown tag
+    // Icon composable is rendered with a Tint semantics; we use the Unknown tag
     val node = composeTestRule.onNodeWithTag(MapIcon.Unknown.tag)
     node.assertIsDisplayed()
     val tintColor = node.fetchSemanticsNode().config.getOrNull(Tint)
@@ -339,31 +347,35 @@ class MapIconTest : BaseAndroidComposeTest() {
 
     // Track state with external control (simulating Map's selectedMarkerId)
     var selectedMarkerId by mutableStateOf<Int?>(null)
-    var capturedShowPolygon = false
+    var polygonCoordsReceived: List<LatLng>? = null
 
     composeTestRule.setContent {
+      // Reset polygon coords on each recomposition
+      polygonCoordsReceived = null
       HazardMarker(
           hazard = hazard,
           selectedMarkerId = selectedMarkerId,
           onMarkerSelected = { selectedMarkerId = it },
-          markerContent = { _, _, _, showPolygon, _, content ->
-            capturedShowPolygon = showPolygon
-            Box { content() }
-          })
+          markerIconProvider = { _, _, _, _ -> null },
+          polygonContent = { coords -> polygonCoordsReceived = coords },
+          markerInfoWindowContent = { _, _, _, _, content -> Box { content() } },
+          iconContent = { _, _ -> })
     }
 
     composeTestRule.waitForIdle()
 
-    // Initially, polygon should not be shown
-    TestCase.assertFalse("Polygon should not be shown initially", capturedShowPolygon)
+    // Initially, polygon should not be shown (polygonContent not called)
+    TestCase.assertNull("Polygon should not be shown initially", polygonCoordsReceived)
 
     // Simulate marker selection
     selectedMarkerId = hazard.id
 
     composeTestRule.waitForIdle()
 
-    // After selection, polygon should be shown
-    TestCase.assertTrue("Polygon should be shown after marker is selected", capturedShowPolygon)
+    // After selection, polygon should be shown (polygonContent called with coords)
+    TestCase.assertNotNull(
+        "Polygon should be shown after marker is selected", polygonCoordsReceived)
+    TestCase.assertTrue("Polygon should have coordinates", polygonCoordsReceived!!.size > 1)
 
     // Simulate clicking outside (clearing selection)
     selectedMarkerId = null
@@ -371,6 +383,268 @@ class MapIconTest : BaseAndroidComposeTest() {
     composeTestRule.waitForIdle()
 
     // After clicking outside, polygon should be hidden again
-    TestCase.assertFalse("Polygon should be hidden after clicking outside", capturedShowPolygon)
+    TestCase.assertNull("Polygon should be hidden after clicking outside", polygonCoordsReceived)
+  }
+
+  @Test
+  fun getSeverityColor_returnsLowForAlertLevel1() {
+    val hazard = hazardBasedOnType("FL").copy(alertLevel = 1.0)
+    TestCase.assertEquals(SeverityColors.LOW, getSeverityColor(hazard))
+  }
+
+  @Test
+  fun getSeverityColor_returnsMediumForAlertLevel2() {
+    val hazard = hazardBasedOnType("FL").copy(alertLevel = 2.0)
+    TestCase.assertEquals(SeverityColors.MEDIUM, getSeverityColor(hazard))
+  }
+
+  @Test
+  fun getSeverityColor_returnsHighForAlertLevel3() {
+    val hazard = hazardBasedOnType("FL").copy(alertLevel = 3.0)
+    TestCase.assertEquals(SeverityColors.HIGH, getSeverityColor(hazard))
+  }
+
+  @Test
+  fun getSeverityColor_returnsUnknownForNullAlertLevel() {
+    val hazard = hazardBasedOnType("FL").copy(alertLevel = null)
+    TestCase.assertEquals(SeverityColors.UNKNOWN, getSeverityColor(hazard))
+  }
+
+  @Test
+  fun getSeverityColor_returnsUnknownForOtherAlertLevels() {
+    val hazard = hazardBasedOnType("FL").copy(alertLevel = 4.0)
+    TestCase.assertEquals(SeverityColors.UNKNOWN, getSeverityColor(hazard))
+
+    val hazard2 = hazardBasedOnType("FL").copy(alertLevel = 0.5)
+    TestCase.assertEquals(SeverityColors.UNKNOWN, getSeverityColor(hazard2))
+  }
+
+  @Test
+  fun hazardNewsImage_displaysFallbackWhenUrlIsNull() {
+    val hazard = hazardBasedOnType("FL").copy(articleUrl = null, description = "Test flood")
+
+    composeTestRule.setContent { HazardNewsImage(hazard = hazard) }
+
+    composeTestRule.waitForIdle()
+    // The image should be displayed (fallback)
+    composeTestRule.onNodeWithContentDescription("Test flood").assertIsDisplayed()
+  }
+
+  @Test
+  fun hazardNewsImage_displaysFallbackWhenUrlIsBlank() {
+    val hazard = hazardBasedOnType("FL").copy(articleUrl = "   ", description = "Test flood blank")
+
+    composeTestRule.setContent { HazardNewsImage(hazard = hazard) }
+
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithContentDescription("Test flood blank").assertIsDisplayed()
+  }
+
+  @Test
+  fun hazardNewsImage_displaysFallbackWhenUrlIsNotImageFormat() {
+    val hazard =
+        hazardBasedOnType("FL")
+            .copy(articleUrl = "https://example.com/news/article", description = "Non-image URL")
+
+    composeTestRule.setContent { HazardNewsImage(hazard = hazard) }
+
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithContentDescription("Non-image URL").assertIsDisplayed()
+  }
+
+  @Test
+  fun hazardNewsImage_usesDefaultDescriptionWhenDescriptionIsNull() {
+    val hazard = hazardBasedOnType("FL").copy(articleUrl = null, description = null)
+
+    composeTestRule.setContent { HazardNewsImage(hazard = hazard) }
+
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithContentDescription("Hazard image").assertIsDisplayed()
+  }
+
+  @Test
+  fun mapIcon_unknownUsesDefaultWarningIcon() {
+    composeTestRule.setContent { MapIcon.Unknown.invoke(tint = Color.Red) }
+
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag(MapIcon.Unknown.tag).assertIsDisplayed()
+
+    // Verify tint is set in semantics
+    val node = composeTestRule.onNodeWithTag(MapIcon.Unknown.tag)
+    val tintColor = node.fetchSemanticsNode().config.getOrNull(Tint)
+    TestCase.assertEquals(Color.Red, tintColor)
+  }
+
+  @Test
+  fun mapIcon_allIconsHaveCorrectTags() {
+    TestCase.assertEquals("map_icon_tsunami", MapIcon.Tsunami.tag)
+    TestCase.assertEquals("map_icon_drought", MapIcon.Drought.tag)
+    TestCase.assertEquals("map_icon_earthquake", MapIcon.Earthquake.tag)
+    TestCase.assertEquals("map_icon_fire", MapIcon.Fire.tag)
+    TestCase.assertEquals("map_icon_flood", MapIcon.Flood.tag)
+    TestCase.assertEquals("map_icon_cyclone", MapIcon.Cyclone.tag)
+    TestCase.assertEquals("map_icon_volcano", MapIcon.Volcano.tag)
+    TestCase.assertEquals("map_icon_unknown", MapIcon.Unknown.tag)
+  }
+
+  @Test
+  fun mapIcon_allKnownIconsHaveResIds() {
+    TestCase.assertNotNull(MapIcon.Tsunami.resId)
+    TestCase.assertNotNull(MapIcon.Drought.resId)
+    TestCase.assertNotNull(MapIcon.Earthquake.resId)
+    TestCase.assertNotNull(MapIcon.Fire.resId)
+    TestCase.assertNotNull(MapIcon.Flood.resId)
+    TestCase.assertNotNull(MapIcon.Cyclone.resId)
+    TestCase.assertNotNull(MapIcon.Volcano.resId)
+    TestCase.assertNull(MapIcon.Unknown.resId)
+  }
+
+  @Test
+  fun hazardInfoWindowContent_hidesArticleHintWhenNoUrl() {
+    val hazard =
+        Hazard(
+            id = 100,
+            type = "FL",
+            description = "Flood without article",
+            country = null,
+            date = null,
+            severity = 50.0,
+            severityUnit = "km",
+            articleUrl = null,
+            alertLevel = 1.0,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    composeTestRule.setContent {
+      HazardInfoWindowContent(
+          hazard = hazard, title = hazard.description, snippet = formatSeveritySnippet(hazard))
+    }
+
+    composeTestRule.onNodeWithText("Flood without article").assertIsDisplayed()
+    composeTestRule.onNodeWithText("50 km").assertIsDisplayed()
+    // Article hint should NOT be present
+    composeTestRule
+        .onAllNodesWithText("Tap this bubble to open the full news article")
+        .assertCountEquals(0)
+  }
+
+  @Test
+  fun hazardInfoWindowContent_showsSeverityText() {
+    val hazard =
+        Hazard(
+            id = 101,
+            type = "EQ",
+            description = "Earthquake with severity text",
+            country = null,
+            date = null,
+            severity = 7.2,
+            severityUnit = "M",
+            severityText = "Magnitude 7.2 - Very strong",
+            articleUrl = "https://example.com",
+            alertLevel = 3.0,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    composeTestRule.setContent {
+      HazardInfoWindowContent(
+          hazard = hazard, title = hazard.description, snippet = formatSeveritySnippet(hazard))
+    }
+
+    composeTestRule.onNodeWithText("Magnitude 7.2 - Very strong").assertIsDisplayed()
+  }
+
+  @Test
+  fun hazardInfoWindowContent_usesDefaultTitleWhenDescriptionNull() {
+    val hazard =
+        Hazard(
+            id = 102,
+            type = "FL",
+            description = null,
+            country = null,
+            date = null,
+            severity = null,
+            severityUnit = null,
+            articleUrl = null,
+            alertLevel = null,
+            bbox = null,
+            affectedZone = null,
+            centroid = null)
+
+    composeTestRule.setContent {
+      HazardInfoWindowContent(hazard = hazard, title = null, snippet = null)
+    }
+
+    // Should show default "Hazard" title
+    composeTestRule.onNodeWithText("Hazard").assertIsDisplayed()
+  }
+
+  @Test
+  fun hazardMarker_invokesOnInfoWindowClickCallback() {
+    var onInfoWindowClickCalled = false
+    val hazard = hazardBasedOnType("FL").copy(articleUrl = "https://example.com/article")
+
+    composeTestRule.setContent {
+      HazardMarker(
+          hazard = hazard,
+          onInfoWindowClick = { onInfoWindowClickCalled = true },
+          markerIconProvider = { _, _, _, _ -> null }, // Avoid Google Maps initialization
+          polygonContent = {},
+          markerInfoWindowContent = { _, _, _, onInfoWindowClick, content ->
+            onInfoWindowClick() // Simulate info window click - this calls our injected callback
+            Box { content() }
+          },
+          iconContent = { _, _ -> })
+    }
+
+    composeTestRule.waitForIdle()
+    TestCase.assertTrue("onInfoWindowClick should have been called", onInfoWindowClickCalled)
+  }
+
+  @Test
+  fun hazardMarker_invokesOnMarkerClickCallback() {
+    var markerClickId: Int? = null
+    val hazard = hazardBasedOnType("FL").copy(id = 999)
+
+    composeTestRule.setContent {
+      HazardMarker(
+          hazard = hazard,
+          onMarkerSelected = { markerClickId = it },
+          markerIconProvider = { _, _, _, _ -> null },
+          polygonContent = {},
+          markerInfoWindowContent = { _, _, onMarkerClick, _, content ->
+            onMarkerClick() // Simulate marker click
+            Box { content() }
+          },
+          iconContent = { _, _ -> })
+    }
+
+    composeTestRule.waitForIdle()
+    TestCase.assertEquals(999, markerClickId)
+  }
+
+  @Test
+  fun formatSeveritySnippet_handlesWholeNumbers() {
+    val hazard = hazardBasedOnType("FL").copy(severity = 100.0, severityUnit = "km")
+    TestCase.assertEquals("100 km", formatSeveritySnippet(hazard))
+  }
+
+  @Test
+  fun formatSeveritySnippet_handlesDecimalNumbers() {
+    val hazard = hazardBasedOnType("FL").copy(severity = 5.67, severityUnit = "M")
+    TestCase.assertEquals("5.7 M", formatSeveritySnippet(hazard))
+  }
+
+  @Test
+  fun formatSeveritySnippet_handlesEmptyUnit() {
+    val hazard = hazardBasedOnType("FL").copy(severity = 42.0, severityUnit = "")
+    TestCase.assertEquals("42", formatSeveritySnippet(hazard))
+  }
+
+  @Test
+  fun formatSeveritySnippet_trimsUnitWhitespace() {
+    val hazard = hazardBasedOnType("FL").copy(severity = 10.0, severityUnit = "  ha  ")
+    TestCase.assertEquals("10 ha", formatSeveritySnippet(hazard))
   }
 }

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/map/Map.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/map/Map.kt
@@ -19,6 +19,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -211,17 +214,24 @@ fun HazardsGoogleMap(
     context: Context = LocalContext.current,
 ) {
   val hazards = uiState.hazardState.hazards
+  var selectedMarkerId by remember { mutableStateOf<Int?>(null) }
 
   GoogleMap(
       modifier = Modifier.fillMaxSize().testTag(MapScreenTestTags.GOOGLE_MAP_SCREEN),
       cameraPositionState = cameraPositionState,
+      onMapClick = { selectedMarkerId = null }, // Clear selection when clicking on map
       uiSettings =
           MapUiSettings(
               myLocationButtonEnabled = false,
               zoomControlsEnabled = true,
               mapToolbarEnabled = false),
       properties = MapProperties(isMyLocationEnabled = uiState.isGranted)) {
-        hazards.forEach { hazard -> HazardMarker(hazard) }
+        hazards.forEach { hazard ->
+          HazardMarker(
+              hazard = hazard,
+              selectedMarkerId = selectedMarkerId,
+              onMarkerSelected = { selectedMarkerId = it })
+        }
 
         uiState.selectedLocation?.let { loc ->
           val pos = toLatLng(loc)

--- a/app/src/main/java/com/github/warnastrophy/core/ui/features/map/Map.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/ui/features/map/Map.kt
@@ -219,7 +219,7 @@ fun HazardsGoogleMap(
   GoogleMap(
       modifier = Modifier.fillMaxSize().testTag(MapScreenTestTags.GOOGLE_MAP_SCREEN),
       cameraPositionState = cameraPositionState,
-      onMapClick = { selectedMarkerId = null }, // Clear selection when clicking on map
+      onMapClick = { selectedMarkerId = null },
       uiSettings =
           MapUiSettings(
               myLocationButtonEnabled = false,


### PR DESCRIPTION
Related to #313 

This PR changes how affected areas are displayed in the Map screen, making them display only when the user clicks on the marker, at the same time as the marker information window.

This improves memory performance taking the number of allocations in a minute down to 36k for the google maps API and 40k for the application package. Note that originally we had 130k + 70k (as mentioned in #313)