### PR TITLE
fix: handle long SMS messages by sending multipart texts

### DIFF
--- a/app/src/main/java/com/github/warnastrophy/core/data/service/SmsService.kt
+++ b/app/src/main/java/com/github/warnastrophy/core/data/service/SmsService.kt
@@ -29,6 +29,13 @@ class SmsManagerSender(context: Context) : SmsSender {
       "Phone number cannot be empty. Please add an emergency contact."
     }
     require(phoneNumber.any { it.isDigit() }) { "Invalid phone number format: $phoneNumber" }
-    smsManager.sendTextMessage(phoneNumber, null, message.toStringMessage(), null, null)
+
+    val messageText = message.toStringMessage()
+    if (messageText.length > 160) {
+      val parts = smsManager.divideMessage(messageText)
+      smsManager.sendMultipartTextMessage(phoneNumber, null, parts, null, null)
+    } else {
+      smsManager.sendTextMessage(phoneNumber, null, messageText, null, null)
+    }
   }
 }

--- a/app/src/test/java/com/github/warnastrophy/core/data/service/SmsServiceTests.kt
+++ b/app/src/test/java/com/github/warnastrophy/core/data/service/SmsServiceTests.kt
@@ -64,11 +64,17 @@ class SmsServiceTests {
   fun sendSms_callsSendTextMessage_API_above_S() {
     Mockito.`when`(mockContext.getSystemService(SmsManager::class.java)).thenReturn(mockSmsManager)
 
+    // The implementation may split long messages and call sendMultipartTextMessage.
+    // Stub divideMessage to return an ArrayList so we can verify the multipart call.
+    Mockito.`when`(mockSmsManager.divideMessage(expectedString))
+        .thenReturn(arrayListOf(expectedString))
+
     smsManagerSender = SmsManagerSender(mockContext)
 
     smsManagerSender.sendSms(phoneNumber, message)
 
-    Mockito.verify(mockSmsManager).sendTextMessage(phoneNumber, null, expectedString, null, null)
+    Mockito.verify(mockSmsManager)
+        .sendMultipartTextMessage(phoneNumber, null, arrayListOf(expectedString), null, null)
   }
 
   @Test
@@ -78,11 +84,16 @@ class SmsServiceTests {
     val mockedStaticSmsManager = Mockito.mockStatic(SmsManager::class.java)
     mockedStaticSmsManager.`when`<SmsManager> { SmsManager.getDefault() }.thenReturn(mockSmsManager)
 
+    // Stub divideMessage similarly for the API < S path
+    Mockito.`when`(mockSmsManager.divideMessage(expectedString))
+        .thenReturn(arrayListOf(expectedString))
+
     smsManagerSender = SmsManagerSender(mockContext)
 
     smsManagerSender.sendSms(phoneNumber, message)
 
-    Mockito.verify(mockSmsManager).sendTextMessage(phoneNumber, null, expectedString, null, null)
+    Mockito.verify(mockSmsManager)
+        .sendMultipartTextMessage(phoneNumber, null, arrayListOf(expectedString), null, null)
 
     mockedStaticSmsManager.close()
   }


### PR DESCRIPTION
This PR fixes the issue of SMSs not being sent when being larger than 160 characters